### PR TITLE
Prevent "ReferenceError: navigator is not defined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var UNDEF = undefined;
 /**
  * We are running in a Mac-like OS?
  */
-var isMacLike = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+var isMacLike = /(Mac|iPhone|iPod|iPad)/i.test(navigator && navigator.platform);
 /**
  * Shorthand to `Object.keys` that returns a more-sense type.
  */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ const UNDEF = undefined
 /**
  * We are running in a Mac-like OS?
  */
-const isMacLike = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)
+const isMacLike = /(Mac|iPhone|iPod|iPad)/i.test(navigator && navigator.platform)
 
 /**
  * Shorthand to `Object.keys` that returns a more-sense type.


### PR DESCRIPTION
This error will show up if you try to use this package with SSR (Server-Side-Render), like in a Next.js app, where there's no `navigator`.

The change should be very safe, but if others get it, to mitigate it for now (because importing from the fork didn't work, I had to run the scripts and link the package locally) you can simply add this piece of code in `pages/_app.tsx`, before `const MyApp`:

```typescript
try {
  // @ts-ignore this is to prevent a problem with react-svg-ionicons
  global.navigator = global.navigator || {};
} catch (error) {
  // Do nothing
}
```

Which will only kick in for SSR, and while in browser it'll silently throw.